### PR TITLE
Win: Work Around MSVC ICE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,8 @@ jobs:
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
-        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        # CXXFLAGS see https://github.com/actions/runner-images/issues/10004
+        CIBW_ENVIRONMENT_WINDOWS: CXXFLAGS="/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
         CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,8 +157,7 @@ jobs:
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
-        # CXXFLAGS see https://github.com/actions/runner-images/issues/10004
-        CIBW_ENVIRONMENT_WINDOWS: CXXFLAGS="/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
         CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
-        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR_TOOLSET=ClangCl HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
         CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -3,6 +3,8 @@ set CURRENTDIR="%cd%"
 set BUILD_PREFIX="C:\Program Files (x86)"
 set CPU_COUNT="4"
 
+set "CMAKE_GENERATOR_TOOLSET=ClangCl"
+
 echo "CFLAGS: %CFLAGS%"
 echo "CXXFLAGS: %CXXFLAGS%"
 echo "LDFLAGS: %LDFLAGS%"


### PR DESCRIPTION
- [ ] CXXFLAGS: https://github.com/BLAST-ImpactX/impactx/pull/893 -- no difference
- [ ] Build in `RelWithDebInfo` ?
- [ ] Disable pybind11 LTO?
- [x] build with ClangCl?

Attempt to fix #1 - internal compiler error (ICE) in MSVC:
```
2025-03-14T18:18:31.9548460Z          "D:\a\impactx-wheels\impactx-wheels\src\build\temp.win-amd64-cpython-39\Release\Release\pyImpactX.vcxproj" (default target) (5) ->
2025-03-14T18:18:31.9548949Z          (Link target) ->
2025-03-14T18:18:31.9549826Z            d:\a\impactx-wheels\impactx-wheels\src\src\python\wakeconvolution.cpp : fatal error C1001: Internal compiler error. [D:\a\impactx-wheels\impactx-wheels\src\build\temp.win-amd64-cpython-39\Release\Release\pyImpactX.vcxproj]
2025-03-14T18:18:31.9551023Z            LINK : fatal error LNK1000: Internal error during IMAGE::BuildImage [D:\a\impactx-wheels\impactx-wheels\src\build\temp.win-amd64-cpython-39\Release\Release\pyImpactX.vcxproj]
```