### PR TITLE
Release 25.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '25.03'
+        ref: '25.04'
 
     - uses: actions/checkout@v4
       with:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -11,7 +11,7 @@ goto:main
 
 :install_buildessentials
   python -m pip install --upgrade pip setuptools wheel
-  python -m pip install --upgrade cmake
+  python -m pip install --upgrade "cmake<4"
   python -m pip install --upgrade "patch==1.*"
 exit /b 0
 
@@ -75,7 +75,8 @@ exit /b 0
     -DBUILD_SHARED_LIBS=OFF ^
     -DBUILD_TESTS=OFF       ^
     -DDISABLE_FORTRAN=ON    ^
-    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   if errorlevel 1 exit 1
 
   cmake --build build-fftw --config Release --parallel %CPU_COUNT%
@@ -93,7 +94,8 @@ exit /b 0
     -DBUILD_TESTS=OFF       ^
     -DDISABLE_FORTRAN=ON    ^
     -DENABLE_FLOAT=ON       ^
-    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   if errorlevel 1 exit 1
 
   cmake --build build-fftw --config Release --parallel %CPU_COUNT%
@@ -131,7 +133,8 @@ exit /b 0
     -DHDF5_ENABLE_SZIP_SUPPORT=OFF ^
     -DHDF5_ENABLE_Z_LIB_SUPPORT=ON ^
     -DZLIB_USE_STATIC_LIBS=ON   ^
-    -DCMAKE_INSTALL_PREFIX=%BUILD_PREFIX%\HDF5
+    -DCMAKE_INSTALL_PREFIX=%BUILD_PREFIX%\HDF5 ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   if errorlevel 1 exit 1
 
   cmake --build build-hdf5 --config Release --parallel %CPU_COUNT%

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -18,7 +18,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=25.03"
+  set "AMREX_VERSION=25.04"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -68,7 +68,7 @@ function install_buildessentials {
 
     python3 -m pip install -U pip setuptools wheel
     python3 -m pip install -U scikit-build
-    python3 -m pip install -U cmake
+    python3 -m pip install -U "cmake<4"
     python3 -m pip install -U "patch==1.*"
 
     touch buildessentials-stamp
@@ -138,7 +138,8 @@ function build_fftw {
       -DBUILD_TESTS=OFF          \
       -DDISABLE_FORTRAN=ON       \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX}
+      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     PATH=${CMAKE_BIN}:${PATH} cmake --build build-fftw --parallel ${CPU_COUNT}
     PATH=${CMAKE_BIN}:${PATH} ${SUDO} cmake --build build-fftw --target install
@@ -156,7 +157,8 @@ function build_fftw {
       -DDISABLE_FORTRAN=ON       \
       -DENABLE_FLOAT=ON          \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX}
+      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     PATH=${CMAKE_BIN}:${PATH} cmake --build build-fftw --parallel ${CPU_COUNT}
     PATH=${CMAKE_BIN}:${PATH} ${SUDO} cmake --build build-fftw --target install
@@ -253,7 +255,8 @@ function build_zlib {
       -B build-zlib \
       -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX}
+      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     PATH=${CMAKE_BIN}:${PATH} cmake --build build-zlib --parallel ${CPU_COUNT}
     PATH=${CMAKE_BIN}:${PATH} ${SUDO} cmake --build build-zlib --target install

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="25.03"
+    AMREX_VERSION="25.04"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 25.04 release.


We expect the following builds to still fail:
- all Windows #1 #2 

With AMReX 25.04, this is the first ImpactX release that will succeed to build:
- 32bit Linux #3 / https://github.com/AMReX-Codes/amrex/pull/4375