### PR TITLE
Release 25.07

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '25.06'
+        ref: '25.07'
 
     - uses: actions/checkout@v4
       with:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -18,7 +18,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=25.06"
+  set "AMREX_VERSION=25.07"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="25.06"
+    AMREX_VERSION="25.07"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 25.07 release.

We expect the following builds to still fail:
- all Windows #1 #2 