### PR TITLE
Release 25.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,12 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install cibuildwheel
       run: |
         python -m pip install --upgrade pip build setuptools[core] wheel
-        python -m pip install cibuildwheel==2.21.2
+        python -m pip install cibuildwheel==3.2.1
 
 #    # Patch: Fix versioning
 #    - name: Download Patch 1/2
@@ -149,7 +149,7 @@ jobs:
         #     https://github.com/AMReX-Codes/amrex/issues/4373
         CIBW_SKIP: "pp*-manylinux* *musllinux*"
         CIBW_ARCHS: "${{ matrix.arch }}"
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
         # Install dependencies
         CIBW_BEFORE_BUILD_LINUX: bash -x .github/library_builders.sh
         CIBW_BEFORE_BUILD_MACOS: bash -x .github/library_builders.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '25.10'
+        ref: '25.11'
 
     - uses: actions/checkout@v4
       with:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -18,7 +18,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=25.10"
+  set "AMREX_VERSION=25.11"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="25.10"
+    AMREX_VERSION="25.11"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 25.11 release.

Support wheels for Python 3.10 to 3.14.

We expect the following builds to still fail:
- all Windows #1 #2 