### PR TITLE
Release 25.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '25.11'
+        ref: '25.12'
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           - name: 64bit macOS
-            os: macos-13
+            os: macos-14
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 11.0
@@ -84,7 +84,7 @@ jobs:
           # HDF5 tricky to build, even with CMake (as of 1.12)
           # We could build them twice and use `lipo` to combine the lib artifacts.
           #- name: 64bit macOS
-          #  os: macos-13
+          #  os: macos-14
           #  arch: "universal2"
           #  env:
           #    CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           - name: 64bit macOS
-            os: macos-14
+            os: macos-15-intel
             arch: "x86_64"
             env:
               MACOSX_DEPLOYMENT_TARGET: 11.0
@@ -84,7 +84,7 @@ jobs:
           # HDF5 tricky to build, even with CMake (as of 1.12)
           # We could build them twice and use `lipo` to combine the lib artifacts.
           #- name: 64bit macOS
-          #  os: macos-14
+          #  os: macos-15-intel
           #  arch: "universal2"
           #  env:
           #    CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -18,7 +18,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=25.11"
+  set "AMREX_VERSION=25.12"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -153,11 +153,11 @@ exit /b 0
 :build_zlib
   if exist zlib-stamp exit /b 0
 
-  curl -sLo zlib-1.2.13.zip ^
-    https://github.com/madler/zlib/archive/v1.2.13.zip
-  powershell Expand-Archive zlib-1.2.13.zip -DestinationPath dep-zlib
+  curl -sLo zlib-1.3.1.zip ^
+    https://github.com/madler/zlib/archive/v1.3.1.zip
+  powershell Expand-Archive zlib-1.3.1.zip -DestinationPath dep-zlib
 
-  cmake -S dep-zlib\zlib-1.2.13 -B build-zlib ^
+  cmake -S dep-zlib\zlib-1.3.1 -B build-zlib ^
     -DBUILD_SHARED_LIBS=ON ^
     -DCMAKE_BUILD_TYPE=Release
   if errorlevel 1 exit 1

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -241,12 +241,12 @@ function build_hdf5 {
 function build_zlib {
     if [ -e zlib-stamp ]; then return; fi
 
-    ZLIB_VERSION="1.2.13"
+    ZLIB_VERSION="1.3.1"
 
-    curl -sLO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
-    file zlib*.tar.gz
-    tar xzf zlib-$ZLIB_VERSION.tar.gz
-    rm zlib*.tar.gz
+    curl -sLO https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VERSION}.tar.gz
+    file v${ZLIB_VERSION}.tar.gz
+    tar xzf v${ZLIB_VERSION}.tar.gz
+    rm v${ZLIB_VERSION}.tar.gz
 
     PY_BIN=$(which python3)
     CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="25.11"
+    AMREX_VERSION="25.12"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 25.12 release.

Support wheels for Python 3.10 to 3.14.

We expect the following builds to still fail:
- all Windows #1 #2 