### PR TITLE
Windows: No LTO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,9 @@ jobs:
         # is set explicitly. On Windows that ends up enabling /GL and /LTCG via pybind11,
         # which currently trips an MSVC ICE in src/python/WakeConvolution.cpp.
         CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_INTERPROCEDURAL_OPTIMIZATION='OFF' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        # cibuildwheel does not repair Windows wheels by default. Since pyAMReX links
+        # against the shared AMReX runtime on Windows, vendor that DLL into the wheel.
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: 'delvewheel repair --add-path "C:\Program Files (x86)\AMReX\bin" -v -w {dest_dir} {wheel}'
         CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,10 @@ jobs:
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 (see setup.py)
         CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
-        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        # ImpactX defaults Python IPO/LTO to ON unless CMAKE_INTERPROCEDURAL_OPTIMIZATION
+        # is set explicitly. On Windows that ends up enabling /GL and /LTCG via pybind11,
+        # which currently trips an MSVC ICE in src/python/WakeConvolution.cpp.
+        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_INTERPROCEDURAL_OPTIMIZATION='OFF' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
         CMAKE_BUILD_PARALLEL_LEVEL: "${{ matrix.env.CMAKE_BUILD_PARALLEL_LEVEL }}"
         # C++17 support in macOS 10.13+ (partial) and 10.14+ (std::visit) and 10.15+ (std::filesystem::path)
         #   https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -12,6 +12,7 @@ goto:main
 :install_buildessentials
   python -m pip install --upgrade pip setuptools wheel
   python -m pip install --upgrade "cmake<4"
+  python -m pip install --upgrade delvewheel
   python -m pip install --upgrade "patch==1.*"
 exit /b 0
 


### PR DESCRIPTION
Trips up MSVC in linking.

Fix #1 
Close #2

- [x] is there a way to solve the DLL issue at the root? Our pip install also [sets PATH for amrex_3d.dll](https://github.com/BLAST-ImpactX/impactx/blob/26.03/.github/workflows/windows.yml#L249) ... yes: https://github.com/AMReX-Codes/pyamrex/pull/559

<details>

  PR 21 on March 25, 2026 and PR 20 on February 10, 2026 both still hit the same Windows failure: the pyImpactX module is compiled with /GL and linked with /LTCG, then MSVC dies during LTCG on src/
  python/wakeconvolution.cpp with C1001, followed by LNK1000. The 32-bit Windows job does the same thing. So this is not a random linker-only failure; it is link-time codegen walking back into that
  translation unit.

  The reason is in upstream ImpactX, not in the wheel helper scripts. In impactx CMakeLists.txt (https://github.com/BLAST-ImpactX/impactx/blob/26.03/CMakeLists.txt), ImpactX_IPO defaults OFF, but Imp
  actX_PYTHON_IPO defaults ON unless CMAKE_INTERPROCEDURAL_OPTIMIZATION is explicitly defined. When ImpactX_PYTHON_IPO is on, pyImpactX links pybind11::lto. In setup.py
  (https://github.com/BLAST-ImpactX/impactx/blob/26.03/setup.py), the wheel build only forwards CMAKE_INTERPROCEDURAL_OPTIMIZATION from the environment, and the wheel workflow was not setting it. That
  is why the build summary can still print IPO/LTO: OFF while the actual Windows commands still contain /GL and /LTCG.

  PR 2 changed the toolset to ClangCl, but it did not disable this IPO/LTO path. So it was working around the compiler choice, not the flag combination that actually triggers the failing LTCG pass. I
  could not confirm the exact PR 2 failure mode because GitHub has already expired that Actions log and now returns HTTP 410 for it. That part is inference.

  I patched the workflow locally at .github/workflows/build.yml:160 to add CMAKE_INTERPROCEDURAL_OPTIMIZATION='OFF' to CIBW_ENVIRONMENT_WINDOWS. That is the cleanest knob here because upstream
  setup.py already forwards it, and upstream CMake already uses it to suppress Python IPO/LTO.
</details>