### PR TITLE
Release 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '26.03'
+        ref: '26.04'
 
     - uses: actions/checkout@v4
       with:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -19,7 +19,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=26.03"
+  set "AMREX_VERSION=26.04"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -25,6 +25,10 @@ exit /b 0
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"
   powershell Expand-Archive "amrex-%AMREX_VERSION%.zip" -DestinationPath dep-amrex
 
+  :: Fix CHANGES.md first-line version (line 1 only; a real # 26.03 section follows)
+  powershell -Command "$f='dep-amrex\amrex-%AMREX_VERSION%\CHANGES.md'; $c=Get-Content $f; $c[0]='# %AMREX_VERSION%'; Set-Content -Path $f -Value $c"
+  if errorlevel 1 exit 1
+
   dir
 
   cmake -S dep-amrex\amrex-%AMREX_VERSION%   ^

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="26.03"
+    AMREX_VERSION="26.04"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -84,6 +84,10 @@ function build_amrex {
     tar xzf amrex-${AMREX_VERSION}.tar.gz
     rm amrex*.tar.gz
 
+    # Fix CHANGES.md first-line version (line 1 only; a real # 26.03 section follows)
+    sed -i.bak "1s/^# .*/# ${AMREX_VERSION}/" amrex/CHANGES.md
+    rm -f amrex/CHANGES.md.bak
+
     PY_BIN=$(which python3)
     CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"
     PATH=${CMAKE_BIN}:${PATH} cmake    \


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 26.04 release.

Support wheels for Python 3.11 to 3.14.

We expect the following builds to still fail:
- Windows 32bit (nice to have in the future, not major platform)