### PR TITLE
Release 26.05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '26.04'
+        ref: '26.05'
 
     - uses: actions/checkout@v4
       with:

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -19,15 +19,11 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=26.04"
+  set "AMREX_VERSION=26.05"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"
   powershell Expand-Archive "amrex-%AMREX_VERSION%.zip" -DestinationPath dep-amrex
-
-  :: Fix CHANGES.md first-line version (line 1 only; a real # 26.03 section follows)
-  powershell -Command "$f='dep-amrex\amrex-%AMREX_VERSION%\CHANGES.md'; $c=Get-Content $f; $c[0]='# %AMREX_VERSION%'; Set-Content -Path $f -Value $c"
-  if errorlevel 1 exit 1
 
   dir
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,16 +77,12 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="26.04"
+    AMREX_VERSION="26.05"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz
     tar xzf amrex-${AMREX_VERSION}.tar.gz
     rm amrex*.tar.gz
-
-    # Fix CHANGES.md first-line version (line 1 only; a real # 26.03 section follows)
-    sed -i.bak "1s/^# .*/# ${AMREX_VERSION}/" amrex/CHANGES.md
-    rm -f amrex/CHANGES.md.bak
 
     PY_BIN=$(which python3)
     CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 26.05 release.

Support wheels for Python 3.11 to 3.14.

We expect the following builds to still fail:
- Windows 32bit (nice to have in the future, not major platform)