### PR TITLE
Release 26.06

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,22 @@ jobs:
             os: ubuntu-24.04
             arch: "x86_64"
             env:
+              SIMD: "ON"
+              WHEEL_ARCHFLAGS: "-march=x86-64-v3 -mtune=generic"
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           - name: 32bit Linux
             os: ubuntu-24.04
             arch: "i686"
             env:
+              SIMD: "OFF"
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           - name: 64bit Linux
             os: ubuntu-24.04-arm
             arch: "aarch64"
             env:
+              SIMD: "ON"
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # builds faster on Travis-CI:
@@ -48,6 +52,10 @@ jobs:
             os: windows-2022
             arch: "AMD64"
             env:
+              # Explicit SIMD (vir-simd) needs clang/gcc builtins, not MSVC, so SIMD stays OFF.
+              # We still target AVX2 via MSVC codegen (/arch:AVX2): scalar FMA + auto-vectorization.
+              SIMD: "OFF"
+              WHEEL_ARCHFLAGS: "/arch:AVX2"
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
           # x86 (32bit)
@@ -55,6 +63,7 @@ jobs:
             os: windows-2022
             arch: "x86"
             env:
+              SIMD: "OFF"
               CMAKE_GENERATOR: "Visual Studio 17 2022"
               CMAKE_GENERATOR_PLATFORM: "Win32"
               CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -63,6 +72,8 @@ jobs:
             os: macos-15-intel
             arch: "x86_64"
             env:
+              SIMD: "ON"
+              WHEEL_ARCHFLAGS: "-march=x86-64-v3 -mtune=generic"
               MACOSX_DEPLOYMENT_TARGET: 11.0
               CMAKE_BUILD_PARALLEL_LEVEL: 4
 
@@ -73,6 +84,7 @@ jobs:
             os: macos-14
             arch: "arm64"
             env:
+              SIMD: "ON"
               CMAKE_OSX_ARCHITECTURES: "arm64"
               MACOSX_DEPLOYMENT_TARGET: 11.0
               CMAKE_BUILD_PARALLEL_LEVEL: 3
@@ -156,11 +168,15 @@ jobs:
         CIBW_BEFORE_BUILD_WINDOWS: 'cmd /E:ON /V:ON /C .github\library_builders.bat'
         # for the openPMD-api build, CMake shall search for
         # static dependencies of HDF5 (see setup.py)
-        CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
+        # SIMD ('${{ matrix.env.SIMD }}') and the x86_64 march/mtune flags are set per matrix arch;
+        # AMREX_SIMD drives the external AMReX build in library_builders.sh, IMPACTX_SIMD the wheel.
+        CIBW_ENVIRONMENT: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' IMPACTX_SIMD='${{ matrix.env.SIMD }}' AMREX_SIMD='${{ matrix.env.SIMD }}' CFLAGS='${{ matrix.env.WHEEL_ARCHFLAGS }}' CXXFLAGS='${{ matrix.env.WHEEL_ARCHFLAGS }}' ZLIB_USE_STATIC_LIBS='ON' PKG_CONFIG_PATH='/usr/local/lib64/pkgconfig;/usr/local/lib/pkgconfig'
         # ImpactX defaults Python IPO/LTO to ON unless CMAKE_INTERPROCEDURAL_OPTIMIZATION
         # is set explicitly. On Windows that ends up enabling /GL and /LTCG via pybind11,
         # which currently trips an MSVC ICE in src/python/WakeConvolution.cpp.
-        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' ZLIB_USE_STATIC_LIBS='ON' CMAKE_INTERPROCEDURAL_OPTIMIZATION='OFF' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
+        # CFLAGS/CXXFLAGS carry /arch:AVX2 on AMD64 only (empty on Win32); CMake seeds these
+        # into both the AMReX pre-build and the ImpactX wheel. No explicit vir-simd SIMD on MSVC.
+        CIBW_ENVIRONMENT_WINDOWS: HDF5_USE_STATIC_LIBRARIES='ON' IMPACTX_AMREX_INTERNAL='OFF' IMPACTX_COMPUTE='NOACC' IMPACTX_FFT='ON' CFLAGS='${{ matrix.env.WHEEL_ARCHFLAGS }}' CXXFLAGS='${{ matrix.env.WHEEL_ARCHFLAGS }}' ZLIB_USE_STATIC_LIBS='ON' CMAKE_INTERPROCEDURAL_OPTIMIZATION='OFF' CMAKE_PREFIX_PATH='C:\Program Files (x86)\AMReX;C:\Program Files (x86)\fftw;C:\Program Files (x86)\zlib'
         # cibuildwheel does not repair Windows wheels by default. Since pyAMReX links
         # against the shared AMReX runtime on Windows, vendor that DLL into the wheel.
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: 'delvewheel repair --add-path "C:\Program Files (x86)\AMReX\bin" -v -w {dest_dir} {wheel}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         repository: 'BLAST-ImpactX/impactx'
         path: 'src'
-        ref: '26.05'
+        ref: '26.06'
 
     - uses: actions/checkout@v4
       with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ImpactX enables high-performance modeling of beam dynamics in particle accelerat
 
 This is a distribution of ImpactX specifically for people that prefer the "pip" installation method.
 
-Because of limitations of pip, we limit this package to be a **sequential CPU build**, i.e., it does not make use of *any* of the accelerated features of ImpactX.
+-Because of limitations of pip, we limit this package to be a **sequential CPU build**, i.e., it does not make use of *any* of the accelerated features of ImpactX besides some light-touch vectorization.
 
 If you need advanced features such as:
 - multi-core CPU support (OpenMP)
@@ -15,7 +15,17 @@ If you need advanced features such as:
 
 then use *another installation method* [as described in our manual](https://impactx.readthedocs.io/en/latest/install/users.html).
 
-If you have any questions or encounter any issues with installing ImpactX, please do not hesitate to [open an issue](https://github.com/BLAST-ImpactX/impactx/issues) or [start a discussion](https://github.com/orgs/BLAST-ImpactX/discussions) to receive help or share feedback.
+If you have any questions or encounter any issues with installing or running ImpactX, please do not hesitate to [open an issue](https://github.com/BLAST-ImpactX/impactx/issues) or [start a discussion](https://github.com/orgs/BLAST-ImpactX/discussions) to receive help or share feedback.
+
+## Supported CPUs
+
+Because the vectorized wheels are compiled for a baseline instruction set, they require a
+reasonably modern CPU (year 2016 or newer):
+
+- **x86-64** Linux/Intel macOS/Windows: Intel CPU of the Haswell generation (2013) or newer,
+  or an AMD CPU of the Excavator (2015) / Zen (2017) generation or newer.
+- **arm64 / aarch64** Linux/Apple Silcon macOS: all ARMv8-A and newer supported
+- **x86-32** 32-bit Linux: all CPUs supported (no SIMD)
 
 ## Documentation
 

--- a/library_builders.bat
+++ b/library_builders.bat
@@ -19,7 +19,7 @@ exit /b 0
 :build_amrex
   if exist amrex-stamp exit /b 0
 
-  set "AMREX_VERSION=26.05"
+  set "AMREX_VERSION=26.06"
 
   curl -sLo "amrex-%AMREX_VERSION%.zip" ^
     "https://github.com/AMReX-Codes/amrex/archive/refs/tags/%AMREX_VERSION%.zip"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -103,6 +103,7 @@ function build_amrex {
       -DAMReX_PARTICLES=ON             \
       -DAMReX_PROBINIT=OFF             \
       -DAMReX_PIC=ON                   \
+      -DAMReX_SIMD=${AMREX_SIMD:-OFF}  \
       -DAMReX_SPACEDIM=3               \
       -DAMReX_TINY_PROFILE=ON          \
       -DAMReX_BUILD_SHARED_LIBS=ON     \
@@ -267,6 +268,31 @@ function build_zlib {
     touch zlib-stamp
 }
 
+function build_virsimd {
+    if [ -e virsimd-stamp ]; then return; fi
+
+    VIRSIMD_VERSION="0.4.4"
+
+    curl -sLO https://github.com/mattkretz/vir-simd/archive/refs/tags/v${VIRSIMD_VERSION}.tar.gz
+    file v${VIRSIMD_VERSION}.tar.gz
+    tar xzf v${VIRSIMD_VERSION}.tar.gz
+    rm v${VIRSIMD_VERSION}.tar.gz
+
+    # header-only: configure + install only (no compilation)
+    PY_BIN=$(which python3)
+    CMAKE_BIN="$(${PY_BIN} -m pip show cmake 2>/dev/null | grep Location | cut -d' ' -f2)/cmake/data/bin/"
+    PATH=${CMAKE_BIN}:${PATH} cmake \
+      -S vir-simd-${VIRSIMD_VERSION} \
+      -B build-virsimd \
+      -DCMAKE_INSTALL_PREFIX=${BUILD_PREFIX} \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    PATH=${CMAKE_BIN}:${PATH} ${SUDO} cmake --build build-virsimd --target install
+
+    rm -rf build-virsimd
+
+    touch virsimd-stamp
+}
+
 # static libs need relocatable symbols for linking to shared python lib
 export CFLAGS+=" -fPIC"
 export CXXFLAGS+=" -fPIC"
@@ -285,4 +311,7 @@ install_buildessentials
 build_fftw
 build_zlib
 build_hdf5
+if [ "${AMREX_SIMD:-OFF}" = "ON" ]; then
+    build_virsimd
+fi
 build_amrex

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -77,7 +77,7 @@ function install_buildessentials {
 function build_amrex {
     if [ -e amrex-stamp ]; then return; fi
 
-    AMREX_VERSION="26.05"
+    AMREX_VERSION="26.06"
 
     curl -sLO https://github.com/AMReX-Codes/amrex/releases/download/${AMREX_VERSION}/amrex-${AMREX_VERSION}.tar.gz
     file amrex*.tar.gz


### PR DESCRIPTION
Build a new PyPI release of wheels for the ImpactX 26.06 release.

Support wheels for Python 3.11 to 3.14.

We expect the following builds to still fail:
- Windows 32bit (nice to have in the future, not major platform)

## New

- [x] build with SIMD support
- [x] x86 CPUs on Linux/macOS: require at least `-march=x86-64-v3` (2016): Intel CPU of the Haswell generation (2013) or newer, or an AMD CPU of the Excavator (2015) / Zen (2017) generation or newer